### PR TITLE
Turn off PWM when duty cycle is set to zero

### DIFF
--- a/src/esp8266/esp_pwm.c
+++ b/src/esp8266/esp_pwm.c
@@ -151,12 +151,12 @@ bool mgos_pwm_set(int pin, int freq, float duty) {
    */
   if (freq > 0 && freq < 10) return false;
 
-  p = find_or_create_pwm_info(pin, (freq > 0));
+  p = find_or_create_pwm_info(pin, (freq > 0) && (duty > 0));
   if (p == NULL) {
     return false;
   }
 
-  if (freq <= 0) {
+  if (freq <= 0 || duty <= 0) {
     remove_pwm_info(p);
     pwm_configure_timer();
     mgos_gpio_write(pin, 0);


### PR DESCRIPTION
It is generally expected that a PWM signal should remain low if it has a
duty cycle of zero. This commit introduces such behaviour by turning PWM
off when duty cycle is set to zero (or lower).

Fixes: https://github.com/mongoose-os-libs/pwm/issues/3